### PR TITLE
Add Coda RAG demo notebook

### DIFF
--- a/coda-rag/py/Coda-RAG.ipynb
+++ b/coda-rag/py/Coda-RAG.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Coda RAG Demo\n",
     "\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/braintrustdata/braintrust-examples/blob/main/coda-rag/py/Coda-RAG-Demo.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/braintrustdata/braintrust-examples/blob/main/coda-rag/py/Coda-RAG.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>\n",
     "\n",
@@ -52,7 +52,7 @@
    "source": [
     "QA_GEN_MODEL = \"gpt-3.5-turbo\"\n",
     "QA_ANSWER_MODEL = \"gpt-3.5-turbo\"\n",
-    "QA_GRADING_MODEL = \"gpt-3.5-turbo\"\n",
+    "QA_GRADING_MODEL = \"gpt-4\"\n",
     "RELEVANCE_MODEL = \"gpt-3.5-turbo\"\n",
     "\n",
     "NUM_SECTIONS = 20\n",

--- a/coda-rag/py/Coda-RAG.ipynb
+++ b/coda-rag/py/Coda-RAG.ipynb
@@ -34,78 +34,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "id": "rTIA4DVQw1K7",
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: autoevals in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.0.40)\n",
-      "Requirement already satisfied: braintrust in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.0.81)\n",
-      "Requirement already satisfied: requests in /Users/austin/code/aphinx/lib/python3.11/site-packages (2.31.0)\n",
-      "Requirement already satisfied: openai in /Users/austin/code/aphinx/lib/python3.11/site-packages (1.5.0)\n",
-      "Requirement already satisfied: lancedb in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.4.0)\n",
-      "Requirement already satisfied: markdownify in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.11.6)\n",
-      "Requirement already satisfied: chevron in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (0.14.0)\n",
-      "Requirement already satisfied: levenshtein in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (0.23.0)\n",
-      "Requirement already satisfied: pyyaml in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (6.0.1)\n",
-      "Requirement already satisfied: braintrust-core>=0.0.6 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (0.0.7)\n",
-      "Requirement already satisfied: GitPython in /Users/austin/code/aphinx/lib/python3.11/site-packages (from braintrust) (3.1.40)\n",
-      "Requirement already satisfied: tqdm in /Users/austin/code/aphinx/lib/python3.11/site-packages (from braintrust) (4.66.1)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (3.3.2)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (3.6)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (2.1.0)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (2023.11.17)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (3.7.1)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (1.8.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (0.25.2)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (2.5.2)\n",
-      "Requirement already satisfied: sniffio in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (1.3.0)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (4.9.0)\n",
-      "Requirement already satisfied: deprecation in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (2.1.0)\n",
-      "Requirement already satisfied: pylance==0.9.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (0.9.0)\n",
-      "Requirement already satisfied: ratelimiter~=1.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (1.2.0.post0)\n",
-      "Requirement already satisfied: retry>=0.9.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (0.9.2)\n",
-      "Requirement already satisfied: aiohttp in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (3.9.1)\n",
-      "Requirement already satisfied: attrs>=21.3.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (23.1.0)\n",
-      "Requirement already satisfied: semver>=3.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (3.0.2)\n",
-      "Requirement already satisfied: cachetools in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (5.3.2)\n",
-      "Requirement already satisfied: click>=8.1.7 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (8.1.7)\n",
-      "Requirement already satisfied: overrides>=0.7 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (7.4.0)\n",
-      "Requirement already satisfied: pyarrow>=12 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pylance==0.9.0->lancedb) (14.0.1)\n",
-      "Requirement already satisfied: numpy>=1.22 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pylance==0.9.0->lancedb) (1.26.2)\n",
-      "Requirement already satisfied: beautifulsoup4<5,>=4.9 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from markdownify) (4.12.2)\n",
-      "Requirement already satisfied: six<2,>=1.15 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from markdownify) (1.16.0)\n",
-      "Requirement already satisfied: soupsieve>1.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from beautifulsoup4<5,>=4.9->markdownify) (2.5)\n",
-      "Requirement already satisfied: httpcore==1.* in /Users/austin/code/aphinx/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai) (1.0.2)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
-      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (0.6.0)\n",
-      "Requirement already satisfied: pydantic-core==2.14.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (2.14.5)\n",
-      "Requirement already satisfied: decorator>=3.4.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from retry>=0.9.2->lancedb) (5.1.1)\n",
-      "Requirement already satisfied: py<2.0.0,>=1.4.26 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from retry>=0.9.2->lancedb) (1.11.0)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (6.0.4)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (1.9.4)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (1.4.0)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (1.3.1)\n",
-      "Requirement already satisfied: packaging in /Users/austin/code/aphinx/lib/python3.11/site-packages (from deprecation->lancedb) (23.2)\n",
-      "Requirement already satisfied: gitdb<5,>=4.0.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from GitPython->braintrust) (4.0.11)\n",
-      "Requirement already satisfied: rapidfuzz<4.0.0,>=3.1.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from levenshtein->autoevals) (3.5.2)\n",
-      "Requirement already satisfied: smmap<6,>=3.0.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->GitPython->braintrust) (5.0.1)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install -U autoevals braintrust requests openai lancedb markdownify"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,9 +55,8 @@
     "QA_GRADING_MODEL = \"gpt-3.5-turbo\"\n",
     "RELEVANCE_MODEL = \"gpt-3.5-turbo\"\n",
     "\n",
-    "NUM_SECTIONS = 20  # Total number of Markdown sections to include in each eval\n",
-    "NUM_QA_PAIRS = 20  # Increase this number to test and fine-tune at a larger scale\n",
-    "TOP_K = 2           # Number of Markdown sections to include as context in RAG prompt"
+    "NUM_SECTIONS = 20\n",
+    "NUM_QA_PAIRS = 20  # Increase this number to test and fine-tune at a larger scale"
    ]
   },
   {
@@ -132,35 +72,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloaded 988 Markdown sections. Here are the first 3:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'doc_id': '8179780',\n",
-       "  'section_id': 0,\n",
-       "  'markdown': \"Not all Coda docs are used in the same way. You'll inevitably have a few that you use every week, and some that you'll only use once. This is where starred docs can help you stay organized.\\n\\n\\n\\nStarring docs is a great way to mark docs of personal importance. After you star a doc, it will live in a section on your doc list called **[My Shortcuts](https://coda.io/shortcuts)**. All starred docs, even from multiple different workspaces, will live in this section.\\n\\n\\n\\nStarring docs only saves them to your personal My Shortcuts. It doesn’t affect the view for others in your workspace. If you’re wanting to shortcut docs not just for yourself but also for others in your team or workspace, you’ll [use pinning](https://help.coda.io/en/articles/2865511-starred-pinned-docs) instead.\"},\n",
-       " {'doc_id': '8179780',\n",
-       "  'section_id': 1,\n",
-       "  'markdown': '**Star your docs**\\n==================\\n\\n\\nTo star a doc, hover over its name in the doc list and click the star icon. Alternatively, you can star a doc from within the doc itself. Hover over the doc title in the upper left corner, and click on the star.\\n\\n\\n\\nOnce you star a doc, you can access it quickly from the [My Shortcuts](https://coda.io/shortcuts) tab of your doc list.\\n\\n\\n\\n![](https://downloads.intercomcdn.com/i/o/793964361/55a80927217f85d68d44a3c3/Star+doc+to+my+shortcuts.gif)And, as your doc needs change, simply click the star again to un-star the doc and remove it from **My Shortcuts**.'},\n",
-       " {'doc_id': '8179780',\n",
-       "  'section_id': 2,\n",
-       "  'markdown': '**FAQs**\\n========\\n\\n\\nWhen should I star a doc and when should I pin it?\\n--------------------------------------------------\\n\\n\\n\\nStarring docs is best for docs of *personal* importance. Starred docs appear in your **My Shortcuts**, but they aren’t starred for anyone else in your workspace. For instance, you may want to star your personal to-do list doc or any docs you use on a daily basis.\\n\\n\\n\\n[Pinning](https://help.coda.io/en/articles/2865511-starred-pinned-docs) is recommended when you want to flag or shortcut a doc for *everyone* in your workspace or folder. For instance, you likely want to pin your company wiki doc to your workspace. And you may want to pin your team task tracker doc to your team’s folder.\\n\\n\\n\\nCan I star docs for everyone?\\n-----------------------------\\n\\n\\n\\nStarring docs only applies to your own view and your own My Shortcuts. To pin docs (or templates) to your workspace or folder, [refer to this article](https://help.coda.io/en/articles/2865511-starred-pinned-docs).\\n\\n\\n\\n\\n\\n---'}]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import asyncio\n",
     "import os\n",
@@ -212,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,27 +239,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generated 204 QA pairs. Here are the first 10...\n",
-      "{'input': 'What is the purpose of starring docs?', 'expected': 'The purpose of starring docs is to mark them as important and easily accessible. Starring a doc helps you stay organized and find important documents quickly.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 0, 'answer_idx': 0, 'id': 0, 'split': 'train'}}\n",
-      "{'input': 'Why should I star a doc?', 'expected': 'The purpose of starring docs is to mark them as important and easily accessible. Starring a doc helps you stay organized and find important documents quickly.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 0, 'answer_idx': 1, 'id': 1, 'split': 'test'}}\n",
-      "{'input': 'Where do starred docs appear in Coda?', 'expected': 'Starred docs appear in the My Shortcuts section of your doc list. When you star a doc, it is added to this section for easy access.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 1, 'answer_idx': 0, 'id': 2, 'split': 'train'}}\n",
-      "{'input': 'What happens when I star a doc?', 'expected': 'Starred docs appear in the My Shortcuts section of your doc list. When you star a doc, it is added to this section for easy access.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 1, 'answer_idx': 1, 'id': 3, 'split': 'test'}}\n",
-      "{'input': 'Can I star docs from different workspaces?', 'expected': 'Yes, you can star docs from multiple different workspaces. All starred docs, regardless of the workspace they belong to, will be stored in the My Shortcuts section.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 2, 'answer_idx': 0, 'id': 4, 'split': 'train'}}\n",
-      "{'input': 'Is it possible to have starred docs from multiple workspaces?', 'expected': 'Yes, you can star docs from multiple different workspaces. All starred docs, regardless of the workspace they belong to, will be stored in the My Shortcuts section.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 2, 'answer_idx': 1, 'id': 5, 'split': 'test'}}\n",
-      "{'input': 'Does starring docs affect the view for others in my workspace?', 'expected': 'No, starring docs only saves them to your personal My Shortcuts. It does not affect the view for others in your workspace. Others will not see the docs you star.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 3, 'answer_idx': 0, 'id': 6, 'split': 'train'}}\n",
-      "{'input': 'Will others in my workspace see the docs I star?', 'expected': 'No, starring docs only saves them to your personal My Shortcuts. It does not affect the view for others in your workspace. Others will not see the docs you star.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 3, 'answer_idx': 1, 'id': 7, 'split': 'test'}}\n",
-      "{'input': 'What should I do if I want to shortcut docs for others in my team or workspace?', 'expected': 'If you want to shortcut docs for others in your team or workspace, you should use pinning instead of starring. Pinning allows you to make shortcut docs visible to others.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 4, 'answer_idx': 0, 'id': 8, 'split': 'train'}}\n",
-      "{'input': 'How can I make shortcut docs visible to others in my team or workspace?', 'expected': 'If you want to shortcut docs for others in your team or workspace, you should use pinning instead of starring. Pinning allows you to make shortcut docs visible to others.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 4, 'answer_idx': 1, 'id': 9, 'split': 'test'}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "all_candidates_tasks = [\n",
     "    asyncio.create_task(produce_candidate_questions(a)) for a in markdown_sections[:NUM_SECTIONS]\n",
@@ -382,59 +278,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Evaluate a context-free prompt (without RAG)\n",
+    "## Evaluate a context-free prompt (no RAG)\n",
     "\n",
     "Now let's evaluate a simple prompt that poses each question without providing any context from the Markdown docs. We'll evaluate this naive approach using (again) `gpt-3.5-turbo`, with the [Factuality prompt](https://github.com/braintrustdata/autoevals/blob/main/templates/factuality.yaml) from the Braintrust [AutoEvals](https://www.braintrustdata.com/docs/autoevals/overview) library."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Experiment No RAG-503a6fb5 is running at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/No%20RAG-503a6fb5\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Coda Help Desk QA [experiment_name=No RAG] (data): 20it [00:00, 145888.83it/s]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f572baabf86e46faabb6806fb4c98515",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Coda Help Desk QA [experiment_name=No RAG] (tasks):   0%|          | 0/20 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=========================SUMMARY=========================\n",
-      "No RAG-503a6fb5 compared to RAG TopK=2-2410214a:\n",
-      "50.00% (-10.00%) 'Factuality' score\t(8 improvements, 10 regressions)\n",
-      "\n",
-      "0.76s (-598.90%) 'duration'\t(20 improvements, 0 regressions)\n",
-      "\n",
-      "See results for No RAG-503a6fb5 at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/No%20RAG-503a6fb5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "async def simple_qa(input):\n",
     "    completion = await simple_completion(\n",
@@ -477,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,10 +388,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "TOP_K = 2\n",
+    "\n",
+    "\n",
     "@braintrust.traced\n",
     "async def relevance_score(query, document):\n",
     "    response = await simple_completion(\n",
@@ -627,52 +483,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Experiment RAG TopK=2-a3ebbacf is running at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/RAG%20TopK%3D2-a3ebbacf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Coda Help Desk QA [experiment_name=RAG TopK=2] (data): 20it [00:00, 79967.66it/s]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0dec88acc7f94cda9829fc75d77ac4f1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Coda Help Desk QA [experiment_name=RAG TopK=2] (tasks):   0%|          | 0/20 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=========================SUMMARY=========================\n",
-      "RAG TopK=2-a3ebbacf compared to No RAG-503a6fb5:\n",
-      "60.00% (+10.00%) 'Factuality' score\t(10 improvements, 8 regressions)\n",
-      "\n",
-      "3.06s (+229.92%) 'duration'\t(0 improvements, 20 regressions)\n",
-      "\n",
-      "See results for RAG TopK=2-a3ebbacf at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/RAG%20TopK%3D2-a3ebbacf\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "await braintrust.Eval(\n",
     "    name=\"Coda Help Desk QA\",\n",

--- a/coda-rag/py/Coda-RAG.ipynb
+++ b/coda-rag/py/Coda-RAG.ipynb
@@ -131,7 +131,8 @@
    "outputs": [],
    "source": [
     "client = braintrust.wrap_openai(openai.AsyncOpenAI(\n",
-    "    base_url=\"https://braintrustproxy.com/v1\", \n",
+    "    base_url=\"https://braintrustproxy.com/v1\",\n",
+    "    default_headers={\"x-bt-use-cache\": \"always\"},\n",
     "    api_key=os.environ[\"OPENAI_API_KEY\"])\n",
     ")"
    ]

--- a/coda-rag/py/Coda-RAG.ipynb
+++ b/coda-rag/py/Coda-RAG.ipynb
@@ -56,7 +56,7 @@
     "RELEVANCE_MODEL = \"gpt-3.5-turbo\"\n",
     "\n",
     "NUM_SECTIONS = 20\n",
-    "NUM_QA_PAIRS = 20  # Increase this number to test and fine-tune at a larger scale"
+    "NUM_QA_PAIRS = 20  # Increase this number to test at a larger scale"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "source": [
     "## Use the Braintrust AI proxy to access the OpenAI API\n",
     "\n",
-    "The [Braintrust AI proxy](https://www.braintrustdata.com/docs/guides/proxy) provides a single API to access OpenAI and Anthropic models, LLaMa 2, Mistral and others. Here we use it to access `gpt-3.5-turbo`. Because the Braintrust AI proxy automatically caches and reuses results when possible (`temperature=0` or `seed` parameter set), we can re-evaluate the following prompts many times without incurring additional API costs."
+    "The [Braintrust AI proxy](https://www.braintrustdata.com/docs/guides/proxy) provides a single API to access OpenAI and Anthropic models, LLaMa 2, Mistral and others. Here we use it to access `gpt-3.5-turbo`. Because the Braintrust AI proxy automatically caches and reuses results (when `temperature=0` or the `seed` parameter is set, or when the caching mode is set to `always`), we can re-evaluate the following prompts many times without incurring additional API costs."
    ]
   },
   {
@@ -130,57 +130,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "markdown_sections = list(reversed(markdown_sections))\n",
+    "\n",
     "client = braintrust.wrap_openai(openai.AsyncOpenAI(\n",
     "    base_url=\"https://braintrustproxy.com/v1\",\n",
     "    default_headers={\"x-bt-use-cache\": \"always\"},\n",
     "    api_key=os.environ[\"OPENAI_API_KEY\"])\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's set up a simple wrapper function to run basic LLM calls while logging relevant metrics and metadata to a Braintrust experiment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@braintrust.traced(name=\"OpenAI Completion\")\n",
-    "async def simple_completion(model, messages, temperature=0, seed=None, **kwargs):\n",
-    "    messages = [{\"role\": \"user\", \"content\": messages}] if isinstance(messages, str) else messages\n",
-    "    for i in range(10):\n",
-    "        try:\n",
-    "            response = await client.chat.completions.create(\n",
-    "                model=model,\n",
-    "                messages=messages,\n",
-    "                temperature=temperature,\n",
-    "                seed=seed,\n",
-    "                **kwargs,\n",
-    "            )\n",
-    "            break\n",
-    "        except Exception as e:\n",
-    "            # Retry with backoff if we hit an OpenAI API rate limit.\n",
-    "            time.sleep(1.1 ** i)\n",
-    "            continue\n",
-    "\n",
-    "    if braintrust.current_span():\n",
-    "        braintrust.current_span().log(\n",
-    "            metrics={\n",
-    "                \"tokens\": response.usage.total_tokens,\n",
-    "                \"prompt_tokens\": response.usage.prompt_tokens,\n",
-    "                \"completion_tokens\": response.usage.completion_tokens,\n",
-    "            },\n",
-    "            metadata={\"model\": model, \"temperature\": temperature, \"seed\": seed},\n",
-    "            input=messages,\n",
-    "            output=response.choices[0].model_dump_json(),\n",
-    "        )\n",
-    "\n",
-    "    return response"
    ]
   },
   {
@@ -215,9 +171,9 @@
     "\n",
     "\n",
     "async def produce_candidate_questions(row):\n",
-    "    response = await simple_completion(\n",
-    "        QA_GEN_MODEL,\n",
-    "        f\"\"\"\n",
+    "    response = await client.chat.completions.create(\n",
+    "        model=QA_GEN_MODEL,\n",
+    "        messages=[{\"role\": \"user\", \"content\": f\"\"\"\\\n",
     "Please generate 8 question/answer pairs from the following text. For each question, suggest\n",
     "2 different ways of phrasing the question, and provide a unique answer.\n",
     "\n",
@@ -225,6 +181,7 @@
     "\n",
     "{row['markdown']}\n",
     "\"\"\",\n",
+    "        }],\n",
     "        functions=[\n",
     "            {\n",
     "                \"name\": \"propose_qa_pairs\",\n",
@@ -291,11 +248,14 @@
    "outputs": [],
    "source": [
     "async def simple_qa(input):\n",
-    "    completion = await simple_completion(\n",
-    "        QA_ANSWER_MODEL,\n",
-    "        f\"\"\"Please answer the following question:\n",
+    "    completion = await client.chat.completions.create(\n",
+    "        model=QA_ANSWER_MODEL,\n",
+    "        messages=[{\"role\": \"user\", \"content\": f\"\"\"\\\n",
+    "Please answer the following question:\n",
     "\n",
-    "Question: {input}\"\"\",\n",
+    "Question: {input}\n",
+    "\"\"\",\n",
+    "        }],\n",
     "    )\n",
     "    return completion.choices[0].message.content\n",
     "\n",
@@ -398,9 +358,9 @@
     "\n",
     "@braintrust.traced\n",
     "async def relevance_score(query, document):\n",
-    "    response = await simple_completion(\n",
-    "        RELEVANCE_MODEL,\n",
-    "        f\"\"\"\\\n",
+    "    response = await client.chat.completions.create(\n",
+    "        model=RELEVANCE_MODEL,\n",
+    "        messages=[{\"role\": \"user\", \"content\": f\"\"\"\\\n",
     "Consider the following query and a document\n",
     "\n",
     "Query:\n",
@@ -412,6 +372,7 @@
     "\n",
     "Please score the relevance of the document to a query, on a scale of 0 to 1.\n",
     "\"\"\",\n",
+    "        }],\n",
     "        functions=[\n",
     "            {\n",
     "                \"name\": \"has_relevance\",\n",
@@ -461,15 +422,18 @@
     "        )\n",
     "\n",
     "    context = \"\\n------\\n\".join(docs[:TOP_K])\n",
-    "    completion = await simple_completion(\n",
-    "        QA_ANSWER_MODEL,\n",
-    "        f\"\"\"Given the following context\n",
+    "    completion = await client.chat.completions.create(\n",
+    "        model=QA_ANSWER_MODEL,\n",
+    "        messages=[{\"role\": \"user\", \"content\": f\"\"\"\\\n",
+    "Given the following context\n",
     "\n",
     "{context}\n",
     "\n",
     "Please answer the following question:\n",
     "\n",
-    "Question: {input}\"\"\",\n",
+    "Question: {input}\n",
+    "\"\"\",\n",
+    "        }],\n",
     "    )\n",
     "    \n",
     "    return completion.choices[0].message.content"

--- a/coda-rag/py/Coda-RAG.ipynb
+++ b/coda-rag/py/Coda-RAG.ipynb
@@ -1,0 +1,725 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vigvBmpNxHvb"
+   },
+   "source": [
+    "# Coda RAG Demo\n",
+    "\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/braintrustdata/braintrust-examples/blob/main/coda-rag/py/Coda-RAG-Demo.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>\n",
+    "\n",
+    "Welcome to [BrainTrust](https://www.braintrustdata.com/)! In this notebook, you'll build and evaluate an AI app that answers questions about Coda's help desk.\n",
+    "\n",
+    "To provide the LLM with relevant information from Coda's help desk, we'll use a technique called RAG (retrieval-augmented generation) to infuse our prompts with text from the most-relevant sections of their docs. To evaluate the performance of our app, we'll use an LLM to generate question-answer pairs from the docs, and we'll use a technique called **model graded evaluation** to automatically evaluate the final responses against the expected answers.\n",
+    "\n",
+    "Before starting, please make sure that you have a BrainTrust account. If you do not, please [sign up](https://www.braintrustdata.com) or [get in touch](mailto:info@braintrustdata.com). After this tutorial, feel free to dig deeper by visiting [the docs](http://www.braintrustdata.com/docs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5AFngU_sw1K5"
+   },
+   "outputs": [],
+   "source": [
+    "# Set your API keys here\n",
+    "%env OPENAI_API_KEY=<YOUR_OPENAI_API_KEY>\n",
+    "%env BRAINTRUST_API_KEY=<YOUR_BRAINTRUST_API_KEY>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "rTIA4DVQw1K7",
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: autoevals in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.0.40)\n",
+      "Requirement already satisfied: braintrust in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.0.81)\n",
+      "Requirement already satisfied: requests in /Users/austin/code/aphinx/lib/python3.11/site-packages (2.31.0)\n",
+      "Requirement already satisfied: openai in /Users/austin/code/aphinx/lib/python3.11/site-packages (1.5.0)\n",
+      "Requirement already satisfied: lancedb in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.4.0)\n",
+      "Requirement already satisfied: markdownify in /Users/austin/code/aphinx/lib/python3.11/site-packages (0.11.6)\n",
+      "Requirement already satisfied: chevron in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (0.14.0)\n",
+      "Requirement already satisfied: levenshtein in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (0.23.0)\n",
+      "Requirement already satisfied: pyyaml in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (6.0.1)\n",
+      "Requirement already satisfied: braintrust-core>=0.0.6 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from autoevals) (0.0.7)\n",
+      "Requirement already satisfied: GitPython in /Users/austin/code/aphinx/lib/python3.11/site-packages (from braintrust) (3.1.40)\n",
+      "Requirement already satisfied: tqdm in /Users/austin/code/aphinx/lib/python3.11/site-packages (from braintrust) (4.66.1)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (3.3.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (3.6)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (2.1.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from requests) (2023.11.17)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (3.7.1)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (1.8.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (0.25.2)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (2.5.2)\n",
+      "Requirement already satisfied: sniffio in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (1.3.0)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from openai) (4.9.0)\n",
+      "Requirement already satisfied: deprecation in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (2.1.0)\n",
+      "Requirement already satisfied: pylance==0.9.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (0.9.0)\n",
+      "Requirement already satisfied: ratelimiter~=1.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (1.2.0.post0)\n",
+      "Requirement already satisfied: retry>=0.9.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (0.9.2)\n",
+      "Requirement already satisfied: aiohttp in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (3.9.1)\n",
+      "Requirement already satisfied: attrs>=21.3.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (23.1.0)\n",
+      "Requirement already satisfied: semver>=3.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (3.0.2)\n",
+      "Requirement already satisfied: cachetools in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (5.3.2)\n",
+      "Requirement already satisfied: click>=8.1.7 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (8.1.7)\n",
+      "Requirement already satisfied: overrides>=0.7 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from lancedb) (7.4.0)\n",
+      "Requirement already satisfied: pyarrow>=12 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pylance==0.9.0->lancedb) (14.0.1)\n",
+      "Requirement already satisfied: numpy>=1.22 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pylance==0.9.0->lancedb) (1.26.2)\n",
+      "Requirement already satisfied: beautifulsoup4<5,>=4.9 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from markdownify) (4.12.2)\n",
+      "Requirement already satisfied: six<2,>=1.15 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from markdownify) (1.16.0)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from beautifulsoup4<5,>=4.9->markdownify) (2.5)\n",
+      "Requirement already satisfied: httpcore==1.* in /Users/austin/code/aphinx/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai) (1.0.2)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
+      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (0.6.0)\n",
+      "Requirement already satisfied: pydantic-core==2.14.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (2.14.5)\n",
+      "Requirement already satisfied: decorator>=3.4.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from retry>=0.9.2->lancedb) (5.1.1)\n",
+      "Requirement already satisfied: py<2.0.0,>=1.4.26 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from retry>=0.9.2->lancedb) (1.11.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (6.0.4)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (1.9.4)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (1.4.0)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from aiohttp->lancedb) (1.3.1)\n",
+      "Requirement already satisfied: packaging in /Users/austin/code/aphinx/lib/python3.11/site-packages (from deprecation->lancedb) (23.2)\n",
+      "Requirement already satisfied: gitdb<5,>=4.0.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from GitPython->braintrust) (4.0.11)\n",
+      "Requirement already satisfied: rapidfuzz<4.0.0,>=3.1.0 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from levenshtein->autoevals) (3.5.2)\n",
+      "Requirement already satisfied: smmap<6,>=3.0.1 in /Users/austin/code/aphinx/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->GitPython->braintrust) (5.0.1)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -U autoevals braintrust requests openai lancedb markdownify"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QA_GEN_MODEL = \"gpt-3.5-turbo\"\n",
+    "QA_ANSWER_MODEL = \"gpt-3.5-turbo\"\n",
+    "QA_GRADING_MODEL = \"gpt-3.5-turbo\"\n",
+    "RELEVANCE_MODEL = \"gpt-3.5-turbo\"\n",
+    "\n",
+    "NUM_SECTIONS = 20  # Total number of Markdown sections to include in each eval\n",
+    "NUM_QA_PAIRS = 20  # Increase this number to test and fine-tune at a larger scale\n",
+    "TOP_K = 2           # Number of Markdown sections to include as context in RAG prompt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c0hvsPRZLCUz"
+   },
+   "source": [
+    "## Download Markdown docs from Coda's help desk\n",
+    "\n",
+    "Let's start by downloading the Coda docs and splitting them into their constituent Markdown sections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloaded 988 Markdown sections. Here are the first 3:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'doc_id': '8179780',\n",
+       "  'section_id': 0,\n",
+       "  'markdown': \"Not all Coda docs are used in the same way. You'll inevitably have a few that you use every week, and some that you'll only use once. This is where starred docs can help you stay organized.\\n\\n\\n\\nStarring docs is a great way to mark docs of personal importance. After you star a doc, it will live in a section on your doc list called **[My Shortcuts](https://coda.io/shortcuts)**. All starred docs, even from multiple different workspaces, will live in this section.\\n\\n\\n\\nStarring docs only saves them to your personal My Shortcuts. It doesn’t affect the view for others in your workspace. If you’re wanting to shortcut docs not just for yourself but also for others in your team or workspace, you’ll [use pinning](https://help.coda.io/en/articles/2865511-starred-pinned-docs) instead.\"},\n",
+       " {'doc_id': '8179780',\n",
+       "  'section_id': 1,\n",
+       "  'markdown': '**Star your docs**\\n==================\\n\\n\\nTo star a doc, hover over its name in the doc list and click the star icon. Alternatively, you can star a doc from within the doc itself. Hover over the doc title in the upper left corner, and click on the star.\\n\\n\\n\\nOnce you star a doc, you can access it quickly from the [My Shortcuts](https://coda.io/shortcuts) tab of your doc list.\\n\\n\\n\\n![](https://downloads.intercomcdn.com/i/o/793964361/55a80927217f85d68d44a3c3/Star+doc+to+my+shortcuts.gif)And, as your doc needs change, simply click the star again to un-star the doc and remove it from **My Shortcuts**.'},\n",
+       " {'doc_id': '8179780',\n",
+       "  'section_id': 2,\n",
+       "  'markdown': '**FAQs**\\n========\\n\\n\\nWhen should I star a doc and when should I pin it?\\n--------------------------------------------------\\n\\n\\n\\nStarring docs is best for docs of *personal* importance. Starred docs appear in your **My Shortcuts**, but they aren’t starred for anyone else in your workspace. For instance, you may want to star your personal to-do list doc or any docs you use on a daily basis.\\n\\n\\n\\n[Pinning](https://help.coda.io/en/articles/2865511-starred-pinned-docs) is recommended when you want to flag or shortcut a doc for *everyone* in your workspace or folder. For instance, you likely want to pin your company wiki doc to your workspace. And you may want to pin your team task tracker doc to your team’s folder.\\n\\n\\n\\nCan I star docs for everyone?\\n-----------------------------\\n\\n\\n\\nStarring docs only applies to your own view and your own My Shortcuts. To pin docs (or templates) to your workspace or folder, [refer to this article](https://help.coda.io/en/articles/2865511-starred-pinned-docs).\\n\\n\\n\\n\\n\\n---'}]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "import os\n",
+    "import re\n",
+    "import time\n",
+    "\n",
+    "import autoevals\n",
+    "import braintrust\n",
+    "import markdownify\n",
+    "import openai\n",
+    "import requests\n",
+    "\n",
+    "\n",
+    "data = requests.get(\n",
+    "    \"https://gist.githubusercontent.com/wong-codaio/b8ea0e087f800971ca5ec9eef617273e/raw/39f8bd2ebdecee485021e20f2c1d40fd649a4c77/articles.json\"\n",
+    ").json()\n",
+    "\n",
+    "markdown_docs = [{\"id\": row[\"id\"], \"markdown\": markdownify.markdownify(row[\"body\"])} for row in data]\n",
+    "\n",
+    "i = 0\n",
+    "markdown_sections = []\n",
+    "for markdown_doc in markdown_docs:\n",
+    "    sections = re.split(r\"(.*\\n=+\\n)\", markdown_doc[\"markdown\"])\n",
+    "    current_section = \"\"\n",
+    "    for section in sections:\n",
+    "        if not section.strip():\n",
+    "            continue\n",
+    "\n",
+    "        if re.match(r\".*\\n=+\\n\", section):\n",
+    "            current_section = section\n",
+    "        else:\n",
+    "            section = current_section + section\n",
+    "            markdown_sections.append({\"doc_id\": markdown_doc[\"id\"], \"section_id\": i, \"markdown\": section.strip()})\n",
+    "            current_section = \"\"\n",
+    "            i += 1\n",
+    "\n",
+    "print(f\"Downloaded {len(markdown_sections)} Markdown sections. Here are the first 3:\")\n",
+    "markdown_sections[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use the Braintrust AI proxy to access the OpenAI API\n",
+    "\n",
+    "The [Braintrust AI proxy](https://www.braintrustdata.com/docs/guides/proxy) provides a single API to access OpenAI and Anthropic models, LLaMa 2, Mistral and others. Here we use it to access `gpt-3.5-turbo`. Because the Braintrust AI proxy automatically caches and reuses results when possible (`temperature=0` or `seed` parameter set), we can re-evaluate the following prompts many times without incurring additional API costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = braintrust.wrap_openai(openai.AsyncOpenAI(\n",
+    "    base_url=\"https://braintrustproxy.com/v1\", \n",
+    "    api_key=os.environ[\"OPENAI_API_KEY\"])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's set up a simple wrapper function to run basic LLM calls while logging relevant metrics and metadata to a Braintrust experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@braintrust.traced(name=\"OpenAI Completion\")\n",
+    "async def simple_completion(model, messages, temperature=0, seed=None, **kwargs):\n",
+    "    messages = [{\"role\": \"user\", \"content\": messages}] if isinstance(messages, str) else messages\n",
+    "    for i in range(10):\n",
+    "        try:\n",
+    "            response = await client.chat.completions.create(\n",
+    "                model=model,\n",
+    "                messages=messages,\n",
+    "                temperature=temperature,\n",
+    "                seed=seed,\n",
+    "                **kwargs,\n",
+    "            )\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            # Retry with backoff if we hit an OpenAI API rate limit.\n",
+    "            time.sleep(1.1 ** i)\n",
+    "            continue\n",
+    "\n",
+    "    if braintrust.current_span():\n",
+    "        braintrust.current_span().log(\n",
+    "            metrics={\n",
+    "                \"tokens\": response.usage.total_tokens,\n",
+    "                \"prompt_tokens\": response.usage.prompt_tokens,\n",
+    "                \"completion_tokens\": response.usage.completion_tokens,\n",
+    "            },\n",
+    "            metadata={\"model\": model, \"temperature\": temperature, \"seed\": seed},\n",
+    "            input=messages,\n",
+    "            output=response.choices[0].model_dump_json(),\n",
+    "        )\n",
+    "\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate question-answer pairs\n",
+    "\n",
+    "Before we start evaluating some prompts, let's first use the LLM to generate a bunch of question/answer pairs from the text at hand. We'll use these QA pairs as ground truth when grading our models later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from typing import List\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "\n",
+    "class QAPair(BaseModel):\n",
+    "    questions: List[str] = Field(\n",
+    "        ..., description=\"List of questions, all with the same meaning but worded differently\"\n",
+    "    )\n",
+    "    answer: str = Field(..., description=\"Answer\")\n",
+    "\n",
+    "\n",
+    "class QAPairs(BaseModel):\n",
+    "    pairs: List[QAPair] = Field(..., description=\"List of question/answer pairs\")\n",
+    "\n",
+    "\n",
+    "async def produce_candidate_questions(row):\n",
+    "    response = await simple_completion(\n",
+    "        QA_GEN_MODEL,\n",
+    "        f\"\"\"\n",
+    "Please generate 8 question/answer pairs from the following text. For each question, suggest\n",
+    "2 different ways of phrasing the question, and provide a unique answer.\n",
+    "\n",
+    "Content:\n",
+    "\n",
+    "{row['markdown']}\n",
+    "\"\"\",\n",
+    "        functions=[\n",
+    "            {\n",
+    "                \"name\": \"propose_qa_pairs\",\n",
+    "                \"description\": \"Propose some question/answer pairs for a given document\",\n",
+    "                \"parameters\": QAPairs.model_json_schema(),\n",
+    "            }\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    pairs = QAPairs(**json.loads(response.choices[0].message.function_call.arguments))\n",
+    "    return pairs.pairs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 204 QA pairs. Here are the first 10...\n",
+      "{'input': 'What is the purpose of starring docs?', 'expected': 'The purpose of starring docs is to mark them as important and easily accessible. Starring a doc helps you stay organized and find important documents quickly.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 0, 'answer_idx': 0, 'id': 0, 'split': 'train'}}\n",
+      "{'input': 'Why should I star a doc?', 'expected': 'The purpose of starring docs is to mark them as important and easily accessible. Starring a doc helps you stay organized and find important documents quickly.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 0, 'answer_idx': 1, 'id': 1, 'split': 'test'}}\n",
+      "{'input': 'Where do starred docs appear in Coda?', 'expected': 'Starred docs appear in the My Shortcuts section of your doc list. When you star a doc, it is added to this section for easy access.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 1, 'answer_idx': 0, 'id': 2, 'split': 'train'}}\n",
+      "{'input': 'What happens when I star a doc?', 'expected': 'Starred docs appear in the My Shortcuts section of your doc list. When you star a doc, it is added to this section for easy access.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 1, 'answer_idx': 1, 'id': 3, 'split': 'test'}}\n",
+      "{'input': 'Can I star docs from different workspaces?', 'expected': 'Yes, you can star docs from multiple different workspaces. All starred docs, regardless of the workspace they belong to, will be stored in the My Shortcuts section.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 2, 'answer_idx': 0, 'id': 4, 'split': 'train'}}\n",
+      "{'input': 'Is it possible to have starred docs from multiple workspaces?', 'expected': 'Yes, you can star docs from multiple different workspaces. All starred docs, regardless of the workspace they belong to, will be stored in the My Shortcuts section.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 2, 'answer_idx': 1, 'id': 5, 'split': 'test'}}\n",
+      "{'input': 'Does starring docs affect the view for others in my workspace?', 'expected': 'No, starring docs only saves them to your personal My Shortcuts. It does not affect the view for others in your workspace. Others will not see the docs you star.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 3, 'answer_idx': 0, 'id': 6, 'split': 'train'}}\n",
+      "{'input': 'Will others in my workspace see the docs I star?', 'expected': 'No, starring docs only saves them to your personal My Shortcuts. It does not affect the view for others in your workspace. Others will not see the docs you star.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 3, 'answer_idx': 1, 'id': 7, 'split': 'test'}}\n",
+      "{'input': 'What should I do if I want to shortcut docs for others in my team or workspace?', 'expected': 'If you want to shortcut docs for others in your team or workspace, you should use pinning instead of starring. Pinning allows you to make shortcut docs visible to others.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 4, 'answer_idx': 0, 'id': 8, 'split': 'train'}}\n",
+      "{'input': 'How can I make shortcut docs visible to others in my team or workspace?', 'expected': 'If you want to shortcut docs for others in your team or workspace, you should use pinning instead of starring. Pinning allows you to make shortcut docs visible to others.', 'metadata': {'document_id': '8179780', 'section_id': 0, 'question_idx': 4, 'answer_idx': 1, 'id': 9, 'split': 'test'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_candidates_tasks = [\n",
+    "    asyncio.create_task(produce_candidate_questions(a)) for a in markdown_sections[:NUM_SECTIONS]\n",
+    "]\n",
+    "all_candidates = [await f for f in all_candidates_tasks]\n",
+    "\n",
+    "data = []\n",
+    "row_id = 0\n",
+    "for row, doc_qa in zip(markdown_sections[:NUM_SECTIONS], all_candidates):\n",
+    "    for i, qa in enumerate(doc_qa):\n",
+    "        for j, q in enumerate(qa.questions):\n",
+    "            data.append(\n",
+    "                {\n",
+    "                    \"input\": q,\n",
+    "                    \"expected\": qa.answer,\n",
+    "                    \"metadata\": {\n",
+    "                        \"document_id\": row[\"doc_id\"],\n",
+    "                        \"section_id\": row[\"section_id\"],\n",
+    "                        \"question_idx\": i,\n",
+    "                        \"answer_idx\": j,\n",
+    "                        \"id\": row_id,\n",
+    "                        \"split\": \"test\" if j == len(qa.questions) - 1 and j > 0 else \"train\",\n",
+    "                    },\n",
+    "                }\n",
+    "            )\n",
+    "            row_id += 1\n",
+    "\n",
+    "print(f\"Generated {len(data)} QA pairs. Here are the first 10...\")\n",
+    "for x in data[:10]:\n",
+    "    print(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate a context-free prompt (without RAG)\n",
+    "\n",
+    "Now let's evaluate a simple prompt that poses each question without providing any context from the Markdown docs. We'll evaluate this naive approach using (again) `gpt-3.5-turbo`, with the [Factuality prompt](https://github.com/braintrustdata/autoevals/blob/main/templates/factuality.yaml) from the Braintrust [AutoEvals](https://www.braintrustdata.com/docs/autoevals/overview) library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment No RAG-503a6fb5 is running at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/No%20RAG-503a6fb5\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Coda Help Desk QA [experiment_name=No RAG] (data): 20it [00:00, 145888.83it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f572baabf86e46faabb6806fb4c98515",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Coda Help Desk QA [experiment_name=No RAG] (tasks):   0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=========================SUMMARY=========================\n",
+      "No RAG-503a6fb5 compared to RAG TopK=2-2410214a:\n",
+      "50.00% (-10.00%) 'Factuality' score\t(8 improvements, 10 regressions)\n",
+      "\n",
+      "0.76s (-598.90%) 'duration'\t(20 improvements, 0 regressions)\n",
+      "\n",
+      "See results for No RAG-503a6fb5 at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/No%20RAG-503a6fb5\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def simple_qa(input):\n",
+    "    completion = await simple_completion(\n",
+    "        QA_ANSWER_MODEL,\n",
+    "        f\"\"\"Please answer the following question:\n",
+    "\n",
+    "Question: {input}\"\"\",\n",
+    "    )\n",
+    "    return completion.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "await braintrust.Eval(\n",
+    "    name=\"Coda Help Desk QA\",\n",
+    "    experiment_name=\"No RAG\",\n",
+    "    data=data[:NUM_QA_PAIRS],\n",
+    "    task=simple_qa,\n",
+    "    scores=[autoevals.Factuality(model=QA_GRADING_MODEL)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pause and click into the experiment in Braintrust!\n",
+    "\n",
+    "The cell above will print a link to a BrainTrust experiment -- click on it to view our baseline eval."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Try using RAG to improve performance\n",
+    "\n",
+    "Let's see if RAG (retrieval-augmented generation) can improve our results on this task.\n",
+    "\n",
+    "First we'll compute embeddings for each Markdown section using `text-embedding-ada-002` and create an index over the embeddings in [LanceDB](https://lancedb.com), a vector database. Then, for any given query, we can convert it to an embedding and efficiently find the most relevant context for an input query by converting it into an embedding and finding the best matches embedding space, and provide the corresponding text as additional context in our prompt.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "import lancedb\n",
+    "\n",
+    "\n",
+    "tempdir = tempfile.TemporaryDirectory()\n",
+    "LANCE_DB_PATH = os.path.join(tempdir.name, \"docs-lancedb\")\n",
+    "\n",
+    "\n",
+    "@braintrust.traced\n",
+    "async def embed_text(text):\n",
+    "    params = dict(input=text, model=\"text-embedding-ada-002\")\n",
+    "    response = await client.embeddings.create(**params)\n",
+    "    embedding = response.data[0].embedding\n",
+    "\n",
+    "    braintrust.current_span().log(\n",
+    "        metrics={\"tokens\": response.usage.total_tokens, \"prompt_tokens\": response.usage.prompt_tokens},\n",
+    "        metadata={\"model\": response.model},\n",
+    "        input=text,\n",
+    "        output=embedding,\n",
+    "    )\n",
+    "    \n",
+    "    return embedding\n",
+    "\n",
+    "\n",
+    "embedding_tasks = [asyncio.create_task(embed_text(row[\"markdown\"])) for row in markdown_sections[:NUM_SECTIONS]]\n",
+    "embeddings = [await f for f in embedding_tasks]\n",
+    "\n",
+    "db = lancedb.connect(LANCE_DB_PATH)\n",
+    "\n",
+    "try:\n",
+    "    db.drop_table(\"sections\")\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "table = db.create_table(\n",
+    "    \"sections\",\n",
+    "    data=[\n",
+    "        {\"doc_id\": row[\"doc_id\"], \"section_id\": row[\"section_id\"], \"vector\": embedding}\n",
+    "        for (row, embedding) in zip(markdown_sections[:NUM_SECTIONS], embeddings)\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use AI to judge relevance of retrieved documents\n",
+    "\n",
+    "We're almost there! One more trick -- let's actually retrieve a few _more_ of the best-matching candidates from the vector database than we intend to use, then use `gpt-3.5-turbo` to score the relevance of each candidate to the input query. We'll use the `TOP_K` blurbs by relevance score in our QA prompt -- this should be a little more intelligent than just using the closest embeddings. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@braintrust.traced\n",
+    "async def relevance_score(query, document):\n",
+    "    response = await simple_completion(\n",
+    "        RELEVANCE_MODEL,\n",
+    "        f\"\"\"\\\n",
+    "Consider the following query and a document\n",
+    "\n",
+    "Query:\n",
+    "{query}\n",
+    "\n",
+    "Document:\n",
+    "{document}\n",
+    "\n",
+    "\n",
+    "Please score the relevance of the document to a query, on a scale of 0 to 1.\n",
+    "\"\"\",\n",
+    "        functions=[\n",
+    "            {\n",
+    "                \"name\": \"has_relevance\",\n",
+    "                \"description\": \"Declare the relevance of a document to a query\",\n",
+    "                \"parameters\": {\n",
+    "                    \"type\": \"object\",\n",
+    "                    \"properties\": {\n",
+    "                        \"score\": {\"type\": \"number\"},\n",
+    "                    },\n",
+    "                },\n",
+    "            }\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    arguments = response.choices[0].message.function_call.arguments\n",
+    "    result = json.loads(arguments)\n",
+    "\n",
+    "    braintrust.current_span().log(\n",
+    "        input={\"query\": query, \"document\": document},\n",
+    "        output=result,\n",
+    "    )\n",
+    "\n",
+    "    return result[\"score\"]\n",
+    "\n",
+    "\n",
+    "async def retrieval_qa(input):\n",
+    "    embedding = await embed_text(input)\n",
+    "\n",
+    "    with braintrust.current_span().start_span(name=\"vector search\", input=input) as span:\n",
+    "        result = table.search(embedding).limit(TOP_K + 3).to_arrow().to_pylist()\n",
+    "        docs = [markdown_sections[i[\"section_id\"]][\"markdown\"] for i in result]\n",
+    "\n",
+    "        relevance_scores = []\n",
+    "        for doc in docs:\n",
+    "            relevance_scores.append(await relevance_score(input, doc))\n",
+    "\n",
+    "        span.log(\n",
+    "            output=[\n",
+    "                {\"doc\": markdown_sections[r[\"section_id\"]][\"markdown\"], \"distance\": r[\"_distance\"]} for r in result\n",
+    "            ],\n",
+    "            metadata={\"top_k\": TOP_K, \"retrieval\": result},\n",
+    "            scores={\n",
+    "                \"avg_relevance\": sum(relevance_scores) / len(relevance_scores),\n",
+    "                \"min_relevance\": min(relevance_scores),\n",
+    "                \"max_relevance\": max(relevance_scores),\n",
+    "            },\n",
+    "        )\n",
+    "\n",
+    "    context = \"\\n------\\n\".join(docs[:TOP_K])\n",
+    "    completion = await simple_completion(\n",
+    "        QA_ANSWER_MODEL,\n",
+    "        f\"\"\"Given the following context\n",
+    "\n",
+    "{context}\n",
+    "\n",
+    "Please answer the following question:\n",
+    "\n",
+    "Question: {input}\"\"\",\n",
+    "    )\n",
+    "    \n",
+    "    return completion.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the RAG evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment RAG TopK=2-a3ebbacf is running at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/RAG%20TopK%3D2-a3ebbacf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Coda Help Desk QA [experiment_name=RAG TopK=2] (data): 20it [00:00, 79967.66it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0dec88acc7f94cda9829fc75d77ac4f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Coda Help Desk QA [experiment_name=RAG TopK=2] (tasks):   0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=========================SUMMARY=========================\n",
+      "RAG TopK=2-a3ebbacf compared to No RAG-503a6fb5:\n",
+      "60.00% (+10.00%) 'Factuality' score\t(10 improvements, 8 regressions)\n",
+      "\n",
+      "3.06s (+229.92%) 'duration'\t(0 improvements, 20 regressions)\n",
+      "\n",
+      "See results for RAG TopK=2-a3ebbacf at https://www.braintrustdata.com/app/austin/p/Coda%20Help%20Desk%20QA/RAG%20TopK%3D2-a3ebbacf\n"
+     ]
+    }
+   ],
+   "source": [
+    "await braintrust.Eval(\n",
+    "    name=\"Coda Help Desk QA\",\n",
+    "    experiment_name=f\"RAG TopK={TOP_K}\",\n",
+    "    data=data[:NUM_QA_PAIRS],\n",
+    "    task=retrieval_qa,\n",
+    "    scores=[autoevals.Factuality(model=QA_GRADING_MODEL)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Click into the new experiment and check it out. You should notice a few things:\n",
+    "- BrainTrust will automatically compare the new experiment to your previous one.\n",
+    "- You should see an increase in scores with RAG. Click around to see exactly which examples improved.\n",
+    "- Try playing around with the constants set at the beginning of this tutorial, such as `NUM_QA_PAIRS`, to evaluate on a larger dataset.\n",
+    "\n",
+    "We hope you had fun with this tutorial! You can learn more about Braintrust at https://www.braintrustdata.com/docs.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds a Coda RAG jupyter notebook based heavily on the `coda_rag.py` example in the main `braintrust` repo. A few notable changes from that example:

- Uses the braintrust proxy to cache results instead of a local cache
- Uses gpt-4 as the grading model instead of gpt-3.5-turbo
- Uses `client.chat.completion.create` instead of `openai.ChatCompletion.acreate` to generate completions, so the responses have to be handled a bit differently
- Uses `wrap_openai` instead of a custom wrapper function defined in the notebook

Fixes BRA-695.